### PR TITLE
Update cuda malloc method

### DIFF
--- a/noReorthog/lanczos.cu
+++ b/noReorthog/lanczos.cu
@@ -423,12 +423,12 @@ void lanczos(int p_nMatrixDimension, dim3 gridDim, dim3 blockDim,
        
             // to do: write code to free memory before allocating for the next iterations.. 
 
-            cublasAlloc(p_nMatrixDimension * (maxIterationsThatFitGPU+ 1), sizeof(float), (void**)&d_aaDMatrixV);
-            cublasAlloc(p_nMatrixDimension, sizeof(float), (void**)&d_aVectorZ);
-            cublasAlloc(p_nMatrixDimension, sizeof(float), (void**)&d_aVectorQQ);
-            cublasAlloc(p_nMatrixDimension, sizeof(float), (void**)&d_aVectorQQPrev);
-            cublasAlloc(p_nMatrixDimension, sizeof(float), (void**)&d_aVectorT1);
-            cublasAlloc(p_nMatrixDimension, sizeof(float), (void**)&d_aVectorT2);
+            cudaMalloc((void**)&d_aaDMatrixV, p_nMatrixDimension * (maxIterationsThatFitGPU+ 1) * sizeof(float));
+            cudaMalloc((void**)&d_aVectorZ, p_nMatrixDimension * sizeof(float));
+            cudaMalloc((void**)&d_aVectorQQ, p_nMatrixDimension * sizeof(float));
+            cudaMalloc((void**)&d_aVectorQQPrev, p_nMatrixDimension * sizeof(float));
+            cudaMalloc((void**)&d_aVectorT1, p_nMatrixDimension * sizeof(float));
+            cudaMalloc((void**)&d_aVectorT2, p_nMatrixDimension * sizeof(float));
 
             cudaMalloc((void**)&devVector, p_nMatrixDimension * sizeof(float));
 


### PR DESCRIPTION
When attempting to run on newer GPU's (In this case a Titan X, compiled using gcc5 and cuda 9.0) the older cublasAlloc wrapper method wasn't working correctly, and gave the following error when running:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  cudaMemcpy(devVector, d_aVectorQQ, nPixels * sizeof(float), cudaMemcpyDeviceToDevice)
  an illegal memory access was encountered
  Aborted (core dumped)
```

Updating `cublasAlloc` to `cudaMalloc` fixes this issue.